### PR TITLE
deactivate coordinates table creation

### DIFF
--- a/data_request_tools/cli.py
+++ b/data_request_tools/cli.py
@@ -1,8 +1,9 @@
 import argparse
+from warnings import warn
 
 import pandas as pd
 
-from . import create_cmor_tables, create_coordinate_table, table_to_json
+from . import create_cmor_tables, table_to_json
 
 
 def main(table, output, prefix, coords=False):
@@ -14,8 +15,11 @@ def main(table, output, prefix, coords=False):
         table_to_json(t, table_prefix=prefix, dir=output)
 
     if coords is True:
-        t = create_coordinate_table(df)
-        table_to_json(t, prefix, table_id="coordinate", dir=output)
+        warn(
+            "Creating coordinate table from data request is deactivated to avoid overwriting the CMOR coordinates table..."
+        )
+        # t = create_coordinate_table(df)
+        # table_to_json(t, prefix, table_id="coordinate", dir=output)
 
 
 def cli():


### PR DESCRIPTION
This was only useful for creating all the different scalar height and pressure coordinate tables. Now, we will have mor individual level request, e.g., for [pressure levels](https://github.com/WCRP-CORDEX/cordex-cmip6-cmor-tables/pull/154). So I'll deactivate this to avoid overwriting the Coordinates cmor table.